### PR TITLE
chore: fix lint-staged commands

### DIFF
--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -2,7 +2,7 @@
   - prettier --list-different
   - eslint
 '*.md':
-  - cspell
+  - cspell check
   - markdownlint-cli2
 '*.{json,yml}':
   - prettier --list-different


### PR DESCRIPTION
Fix the lint-staged command for cspell. It was missing an additional part of the command to check files individually via lint-staged.