### PR TITLE
chore: add concurrency rule to workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,8 @@ name: Bug Report
 description: File a bug report.
 title: "[Bug]: "
 labels: ["bug", "triage"]
+assignees:
+  - zksync-sdk/devxp
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,6 @@ body:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: ""
     validations:
       required: true
   - type: textarea
@@ -23,7 +22,6 @@ body:
     attributes:
       label: What did you expect to happen?
       placeholder: Tell us what you expected!
-      value: ""
   - type: textarea
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,8 @@ name: Feature Request
 description: Is there a feature missing you would like to see? Let us know!
 title: "[Feature]: "
 labels: ["feature", "triage"]
+assignees:
+  - zksync-sdk/devxp
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,14 +15,12 @@ body:
       label: Description
       description: Please provide a brief description of the feature you would like to see.
       placeholder: Tell us what you would like to see!
-      value: ""
   - type: textarea
     id: rationale
     attributes:
       label: Rationale
       description: Why do you think this feature would be beneficial to the community?
       placeholder: Tell us why you think this feature would be beneficial!
-      value: ""
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -2,6 +2,8 @@ name: Feedback
 description: Please share any feedback for us on our content!
 title: "[Feedback]: "
 labels: ["feedback", "triage"]
+assignees:
+  - zksync-sdk/devxp
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -15,14 +15,12 @@ body:
       label: Page
       description: If this is related to a specific page, please provide the URL.
       placeholder: https://docs.zksync.io/page
-      value: ""
   - type: textarea
     id: description
     attributes:
       label: Description
       description: Please provide a brief description of the feedback you would like to share.
       placeholder: Tell us what you would like to share!
-      value: ""
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,6 +8,10 @@ env:
   HUSKY: 0
   NUXT_SITE_ENV: staging # used for NuxtSEO to disable things like indexing on staging
 
+concurrency:
+  group: staging
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy:
     env:


### PR DESCRIPTION
# Description

Add concurrency rules to workflows for staging deploy workflows. This cancels any currently running workflow when a new workflow is set to run. For example when two PRs are merged to main around the same time, one will cancel out the other and only one workflow is run to deploy.
This makes it so that we don't have a queue of build and deploys to run, cutting down time and resources.

Fix yaml formatting errors with github issue templates. They do not list in Create Issues if format is incorrect.