### PR TITLE
feat: update url

### DIFF
--- a/pages/sdk/[...slug].vue
+++ b/pages/sdk/[...slug].vue
@@ -51,7 +51,7 @@ const links = computed(() =>
     {
       icon: 'i-heroicons-chat-bubble-oval-left-ellipsis',
       label: 'Share feedback',
-      to: `https://github.com/zksync-sdk/sdk-docs/issues/new?&template=feedback&page=https://docs.zksync.io${page?.value?._path}`,
+      to: `https://zksync.io/contact`,
       target: '_blank',
     },
     ...(toc?.bottom?.links || []),


### PR DESCRIPTION
What

- edit URLof feedback page to the correct URL

Why

- the old URL points to a wrong destination