### PR TITLE
chore: update commit-analyzer rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Is there a feature missing you would like to see? Let us know!
 title: "[Feature]: "
-labels: ["feature", "triage"]
+labels: ["enhancement", "triage"]
 assignees:
   - zksync-sdk/devxp
 body:

--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,18 @@
   "addReleases": "top",
   "npmPublish": false,
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {
+            "type": "docs",
+            "release": "minor"
+          }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ]


### PR DESCRIPTION
# Description

Add rule for commit-analyzer to identify `docs` tags for commits as minor releases.