### PR TITLE
chore: add search back in

### DIFF
--- a/server/api/search.json.get.ts
+++ b/server/api/search.json.get.ts
@@ -1,0 +1,7 @@
+import { serverQueryContent } from '#content/server';
+
+export default eventHandler(async (event) => {
+  return serverQueryContent(event)
+    .where({ _type: 'markdown', navigation: { $ne: false } })
+    .find();
+});


### PR DESCRIPTION

# Description

The search feature was removed in the last commit. This commit adds it back in. 
It was removed because it is not being used in this project. 
However, due to how the nuxt layers is building, it is erroring on build because it is missing. 
This adds it back in to handle the error for now.

Search functionality will be replaced with an improved search feature in the future so not worried about having this in here for now to silence errors.
