### PR TITLE
chore: remove the appendix for toJSON function

### DIFF
--- a/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/01.provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/01.provider.md
@@ -44,7 +44,7 @@ async estimateFee(transaction: TransactionRequest): Promise<Fee>
 ```
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const fee = await provider.estimateFee({
@@ -129,7 +129,7 @@ async estimateGasL1(transaction: TransactionRequest): Promise<BigNumber>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const gasL1 = await provider.estimateGasL1({
@@ -264,7 +264,7 @@ async estimateL1ToL2Execute(transaction: {
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const gasL1ToL2 = await provider.estimateL1ToL2Execute({
@@ -296,7 +296,7 @@ async getAllAccountBalances(address: Address): Promise<BalancesMap>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const balances = await provider.getAllAccountBalances("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049");
@@ -324,7 +324,7 @@ async getBalance(address: Address, blockTag?: BlockTag, tokenAddress?: Address)
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const account = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
@@ -346,7 +346,7 @@ async getBaseTokenContractAddress(): Promise<Address>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Base token: ${await provider.getBaseTokenContractAddress()}`);
@@ -363,7 +363,7 @@ async getBlock(blockHashOrBlockTag: BlockTag | string | Promise<BlockTag | strin
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Block: ${toJSON(await provider.getBlock("latest", true))}`);
@@ -388,7 +388,7 @@ async getBlockDetails(number:number): Promise<BlockDetails>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Block details: ${toJSON(await provider.getBlockDetails(90_000))}`);
@@ -407,7 +407,7 @@ async getBridgehubContractAddress(): Promise<Address>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Bridgehub: ${await provider.getBridgehubContractAddress()}`);
@@ -432,7 +432,7 @@ async getBytecodeByHash(bytecodeHash: BytesLike): Promise<Uint8Array>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 // Bytecode hash can be computed by following these steps:
 // const testnetPaymasterBytecode = await provider.getCode(await provider.getTestnetPaymasterAddress());
@@ -489,7 +489,7 @@ async getContractAccountInfo(address:Address): Promise<ContractAccountInfo>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const tokenAddress = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
@@ -514,7 +514,7 @@ getDefaultBridgeAddresses(): Promise<{
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Default bridges: ${toJSON(await provider.getDefaultBridgeAddresses())}`);
@@ -538,7 +538,7 @@ async connectL2Bridge(address: Address): Promise<Il2SharedBridge | Il2Bridge>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l2Bridge = await provider.connectL2Bridge("<L2_BRIDGE_ADDRESS>");
@@ -561,7 +561,7 @@ async isL2BridgeLegacy(address: Address): Promise<boolean>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const isBridgeLegacy = await provider.isL2BridgeLegacy("<L2_BRIDGE_ADDRESS>");
@@ -585,7 +585,7 @@ static getDefaultProvider(zksyncNetwork: ZkSyncNetwork = ZkSyncNetwork.Localhost
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const providerMainnet = Provider.getDefaultProvider(types.Network.Mainnet);
 const providerTestnet = Provider.getDefaultProvider(types.Network.Sepolia);
@@ -652,7 +652,7 @@ static override getFormatter(): Formatter
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const formatter = Provider.getFormatter();
 ```
@@ -668,7 +668,7 @@ async getGasPrice(): Promise<BigNumber>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Gas price: ${await provider.getGasPrice()}`);
@@ -694,7 +694,7 @@ async getL1BatchBlockRange(l1BatchNumber: number): Promise<[number, number] | nu
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
@@ -720,7 +720,7 @@ async getL1BatchDetails(number: number): Promise<BatchDetails>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
@@ -740,7 +740,7 @@ async getL1BatchNumber(): Promise<number>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L1 batch number: ${await provider.getL1BatchNumber()}`);
@@ -763,7 +763,7 @@ async getL2TransactionFromPriorityOp(l1TxResponse: ethers.TransactionResponse): 
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const ethProvider = ethers.getDefaultProvider("sepolia");
@@ -794,7 +794,7 @@ async getLogProof(txHash: BytesLike, index ? : number): Promise<MessageProof | n
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 // Any L2 -> L1 transaction can be used.
@@ -821,7 +821,7 @@ getLogs(filter: Filter | FilterByBlockHash | Promise<Filter | FilterByBlockHash>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Logs: ${toJSON(await provider.getLogs({ fromBlock: 0, toBlock: 5, address: utils.L2_ETH_TOKEN_ADDRESS }))}`);
@@ -840,7 +840,7 @@ async getMainContractAddress(): Promise<Address>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Main contract: ${await provider.getMainContractAddress()}`);
@@ -896,7 +896,7 @@ async getPriorityOpResponse(l1TxResponse: ethers.TransactionResponse): Promise<P
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const ethProvider = ethers.getDefaultProvider("sepolia");
@@ -974,7 +974,7 @@ async getProtocolVersion(id?: number): Promise<ProtocolVersion>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Protocol version: ${await provider.getProtocolVersion()}`);
@@ -1000,7 +1000,7 @@ async getRawBlockTransactions(number: number): Promise<RawBlockTransaction[]>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Raw block transactions: ${toJSON(await provider.getRawBlockTransactions(90_000))}`);
@@ -1018,7 +1018,7 @@ async getTestnetPaymasterAddress(): Promise<Address | null>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Testnet paymaster: ${await provider.getTestnetPaymasterAddress()}`);
@@ -1042,7 +1042,7 @@ async getTransaction(hash: string | Promise<string>): Promise<TransactionRespons
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
@@ -1075,7 +1075,7 @@ async getTransactionDetails(txHash: BytesLike): Promise<TransactionDetails>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
@@ -1102,7 +1102,7 @@ async getTransactionReceipt(transactionHash: string | Promise<string>): Promise<
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
@@ -1126,7 +1126,7 @@ async getTransactionStatus(txHash: string): Promise<TransactionStatus>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
@@ -1289,7 +1289,7 @@ async isBaseToken(token: Address): Promise<string>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Is base token: ${await provider.isBaseToken("0x5C221E77624690fff6dd741493D735a17716c26B")}`);
@@ -1306,7 +1306,7 @@ async isEthBasedChain(): Promise<boolean>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Is ETH based chain: ${await provider.isEthBasedChain()}`);
@@ -1325,7 +1325,7 @@ async l1ChainId(): Promise<number>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L1 chain ID: ${await provider.l1ChainId()}`);
@@ -1353,7 +1353,7 @@ async l1TokenAddress(token: Address): Promise<string>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L1 token address: ${await provider.l1TokenAddress("0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b")}`);
@@ -1382,7 +1382,7 @@ async l2TokenAddress(token: Address): Promise<string>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L2 token address: ${await provider.l2TokenAddress("0x5C221E77624690fff6dd741493D735a17716c26B")}`);
@@ -1400,7 +1400,7 @@ async newBlockFilter(): Promise<BigNumber>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`New block filter: ${await provider.newBlockFilter()}`);
@@ -1450,7 +1450,7 @@ async newPendingTransactionsFilter(): Promise<BigNumber>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`New pending transaction filter: ${await provider.newPendingTransactionsFilter()}`);

--- a/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/01.provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/01.provider.md
@@ -52,7 +52,7 @@ const fee = await provider.estimateFee({
   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
   value: `0x${BigNumber.from(7_000_000_000).toString(16)}`,
 });
-console.log(`Fee: ${toJSON(fee)}`);
+console.log(`Fee: ${utils.toJSON(fee)}`);
 ```
 
 ### `estimateGas`
@@ -300,7 +300,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const balances = await provider.getAllAccountBalances("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049");
-console.log(`All balances: ${toJSON(balances)}`);
+console.log(`All balances: ${utils.toJSON(balances)}`);
 ```
 
 ### `getBalance`
@@ -366,7 +366,7 @@ async getBlock(blockHashOrBlockTag: BlockTag | string | Promise<BlockTag | strin
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Block: ${toJSON(await provider.getBlock("latest", true))}`);
+console.log(`Block: ${utils.toJSON(await provider.getBlock("latest", true))}`);
 ```
 
 ### `getBlockDetails`
@@ -391,7 +391,7 @@ async getBlockDetails(number:number): Promise<BlockDetails>
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Block details: ${toJSON(await provider.getBlockDetails(90_000))}`);
+console.log(`Block details: ${utils.toJSON(await provider.getBlockDetails(90_000))}`);
 ```
 
 ### `getBridgehubContractAddress`
@@ -493,7 +493,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const tokenAddress = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
-console.log(`Contract account info: ${toJSON(await provider.getContractAccountInfo(tokenAddress))}`);
+console.log(`Contract account info: ${utils.toJSON(await provider.getContractAccountInfo(tokenAddress))}`);
 ```
 
 ### `getDefaultBridgeAddresses`
@@ -517,7 +517,7 @@ getDefaultBridgeAddresses(): Promise<{
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Default bridges: ${toJSON(await provider.getDefaultBridgeAddresses())}`);
+console.log(`Default bridges: ${utils.toJSON(await provider.getDefaultBridgeAddresses())}`);
 ```
 
 ### `connectL2Bridge`
@@ -698,7 +698,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
-console.log(`L1 batch block range: ${toJSON(await provider.getL1BatchBlockRange(l1BatchNumber))}`);
+console.log(`L1 batch block range: ${utils.toJSON(await provider.getL1BatchBlockRange(l1BatchNumber))}`);
 ```
 
 ### `getL1BatchDetails`
@@ -724,7 +724,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
-console.log(`L1 batch details: ${toJSON(await provider.getL1BatchDetails(l1BatchNumber))}`);
+console.log(`L1 batch details: ${utils.toJSON(await provider.getL1BatchDetails(l1BatchNumber))}`);
 ```
 
 ### `getL1BatchNumber`
@@ -770,7 +770,7 @@ const ethProvider = ethers.getDefaultProvider("sepolia");
 const l1Tx = "0xcca5411f3e514052f4a4ae1c2020badec6e0998adb52c09959c5f5ff15fba3a8";
 const l1TxResponse = await ethProvider.getTransaction(l1Tx);
 if (l1TxResponse) {
-  console.log(`Tx: ${toJSON(await provider.getL2TransactionFromPriorityOp(l1TxResponse))}`);
+  console.log(`Tx: ${utils.toJSON(await provider.getL2TransactionFromPriorityOp(l1TxResponse))}`);
 }
 ```
 
@@ -800,7 +800,7 @@ const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 // Any L2 -> L1 transaction can be used.
 // In this case, withdrawal transaction is used.
 const tx = "0x2a1c6c74b184965c0cb015aae9ea134fd96215d2e4f4979cfec12563295f610e";
-console.log(`Log ${toJSON(await provider.getLogProof(tx, 0))}`);
+console.log(`Log ${utils.toJSON(await provider.getLogProof(tx, 0))}`);
 ```
 
 ### `getLogs`
@@ -824,7 +824,7 @@ getLogs(filter: Filter | FilterByBlockHash | Promise<Filter | FilterByBlockHash>
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Logs: ${toJSON(await provider.getLogs({ fromBlock: 0, toBlock: 5, address: utils.L2_ETH_TOKEN_ADDRESS }))}`);
+console.log(`Logs: ${utils.toJSON(await provider.getLogs({ fromBlock: 0, toBlock: 5, address: utils.L2_ETH_TOKEN_ADDRESS }))}`);
 ```
 
 ### `getMainContractAddress`
@@ -903,7 +903,7 @@ const ethProvider = ethers.getDefaultProvider("sepolia");
 const l1Tx = "0xcca5411f3e514052f4a4ae1c2020badec6e0998adb52c09959c5f5ff15fba3a8";
 const l1TxResponse = await ethProvider.getTransaction(l1Tx);
 if (l1TxResponse) {
-  console.log(`Tx: ${toJSON(await provider.getPriorityOpResponse(l1TxResponse))}`);
+  console.log(`Tx: ${utils.toJSON(await provider.getPriorityOpResponse(l1TxResponse))}`);
 }
 ```
 
@@ -952,7 +952,7 @@ const storageKey = ethers.utils.keccak256(concatenated);
 
 const l1BatchNumber = await provider.getL1BatchNumber();
 const storageProof = await provider.getProof(utils.NONCE_HOLDER_ADDRESS, [storageKey], l1BatchNumber);
-console.log(`Storage proof: ${toJSON(storageProof)}`);
+console.log(`Storage proof: ${utils.toJSON(storageProof)}`);
 ```
 
 ### `getProtocolVersion`
@@ -1003,7 +1003,7 @@ async getRawBlockTransactions(number: number): Promise<RawBlockTransaction[]>
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Raw block transactions: ${toJSON(await provider.getRawBlockTransactions(90_000))}`);
+console.log(`Raw block transactions: ${utils.toJSON(await provider.getRawBlockTransactions(90_000))}`);
 ```
 
 ### `getTestnetPaymasterAddress`
@@ -1080,7 +1080,7 @@ import { Provider, types, utils } from "zksync-ethers";
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-console.log(`Transaction details: ${toJSON(await provider.getTransactionDetails(TX_HASH))}`);
+console.log(`Transaction details: ${utils.toJSON(await provider.getTransactionDetails(TX_HASH))}`);
 ```
 
 ### `getTransactionReceipt`
@@ -1106,7 +1106,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-console.log(`Transaction receipt: ${toJSON(await provider.getTransactionReceipt(TX_HASH))}`);
+console.log(`Transaction receipt: ${utils.toJSON(await provider.getTransactionReceipt(TX_HASH))}`);
 ```
 
 ### `getTransactionStatus`
@@ -1131,7 +1131,7 @@ import { Provider, types, utils } from "zksync-ethers";
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-console.log(`Transaction status: ${toJSON(await provider.getTransactionStatus(TX_HASH))}`);
+console.log(`Transaction status: ${utils.toJSON(await provider.getTransactionStatus(TX_HASH))}`);
 ```
 
 ### `getTransferTx`

--- a/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/01.provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/01.provider.md
@@ -43,8 +43,6 @@ Returns an estimated [`Fee`](/sdk/js/ethers/api/v5/types#fee) for requested tran
 async estimateFee(transaction: TransactionRequest): Promise<Fee>
 ```
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -297,8 +295,6 @@ async getAllAccountBalances(address: Address): Promise<BalancesMap>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -366,8 +362,6 @@ async getBlock(blockHashOrBlockTag: BlockTag | string | Promise<BlockTag | strin
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -392,8 +386,6 @@ async getBlockDetails(number:number): Promise<BlockDetails>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -472,8 +464,6 @@ async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
 
@@ -497,8 +487,6 @@ async getContractAccountInfo(address:Address): Promise<ContractAccountInfo>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -524,8 +512,6 @@ getDefaultBridgeAddresses(): Promise<{
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -619,8 +605,6 @@ async getFeeParams(): Promise<FeeParams>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
 
@@ -709,8 +693,6 @@ async getL1BatchBlockRange(l1BatchNumber: number): Promise<[number, number] | nu
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -736,8 +718,6 @@ async getL1BatchDetails(number: number): Promise<BatchDetails>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -782,8 +762,6 @@ async getL2TransactionFromPriorityOp(l1TxResponse: ethers.TransactionResponse): 
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -815,8 +793,6 @@ async getLogProof(txHash: BytesLike, index ? : number): Promise<MessageProof | n
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -843,8 +819,6 @@ getLogs(filter: Filter | FilterByBlockHash | Promise<Filter | FilterByBlockHash>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -894,8 +868,6 @@ async getPriorityOpConfirmation(txHash: string, index: number = 0): Promise<{
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
 
@@ -922,8 +894,6 @@ async getPriorityOpResponse(l1TxResponse: ethers.TransactionResponse): Promise<P
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -957,8 +927,6 @@ async getProof(address: Address, keys: string[], l1BatchNumber: number): Promise
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
@@ -1030,8 +998,6 @@ async getRawBlockTransactions(number: number): Promise<RawBlockTransaction[]>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -1108,8 +1074,6 @@ async getTransactionDetails(txHash: BytesLike): Promise<TransactionDetails>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -1137,8 +1101,6 @@ async getTransactionReceipt(transactionHash: string | Promise<string>): Promise<
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -1162,8 +1124,6 @@ async getTransactionStatus(txHash: string): Promise<TransactionStatus>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -1522,8 +1482,6 @@ async sendRawTransactionWithDetailedOutput(signedTx: string): Promise<Transactio
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
 
 ```ts
 import { Provider, Wallet, types, utils } from "zksync-ethers";

--- a/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/02.web3provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/00.providers/02.web3provider.md
@@ -839,20 +839,3 @@ const message = "Hello, ZKsync!";
 const signature = await signer.signMessage(message);
 console.log(`Signature: ${signature}`);
 ```
-
-## Appendix
-
-### toJSON
-
-Helper function to convert objects to JSON string with BigInt support.
-
-```ts
-function toJSON(object: any): string {
-  return JSON.stringify(object, (key, value) => {
-    if (typeof value === "bigint") {
-      return value.toString(); // Convert BigInt to string
-    }
-    return value;
-  });
-}
-```

--- a/content/sdk/10.js/00.ethers/05.api/10.v5/01.accounts/01.wallet.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/01.accounts/01.wallet.md
@@ -1919,8 +1919,6 @@ async getPriorityOpConfirmation(txHash: string, index: number = 0): Promise<{
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Wallet, Provider, types, utils } from "zksync-ethers";
 import { ethers } from "ethers";

--- a/content/sdk/10.js/00.ethers/05.api/10.v5/01.accounts/03.l1signer.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/01.accounts/03.l1signer.md
@@ -1073,8 +1073,6 @@ async getPriorityOpConfirmation(txHash: string, index: number = 0): Promise<{
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v5/providers/web3provider#tojson).
-
 ```ts
 import { Provider, L1Signer, types } from "zksync-ethers";
 import { ethers } from "ethers";

--- a/content/sdk/10.js/00.ethers/05.api/10.v5/01.accounts/03.l1signer.md
+++ b/content/sdk/10.js/00.ethers/05.api/10.v5/01.accounts/03.l1signer.md
@@ -10,7 +10,7 @@ This class extends `ethers.providers.JsonRpcSigner` and so supports all the meth
 The easiest way to construct it is from an `Web3Provider` object.
 
 ```ts
-import { Provider, L1Signer, types } from "zksync-ethers";
+import { Provider, L1Signer, types, utils } from "zksync-ethers";
 import { ethers } from "ethers";
 
 const provider = new ethers.providers.Web3Provider(window.ethereum);

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/01.provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/01.provider.md
@@ -99,7 +99,7 @@ const fee = await provider.estimateFee({
   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
   value: `0x${BigInt(7_000_000_000).toString(16)}`,
 });
-console.log(`Fee: ${toJSON(fee)}`);
+console.log(`Fee: ${utils.toJSON(fee)}`);
 ```
 
 The `estimateFee` method estimates the fee required for a transaction. This is important for users to know how much they
@@ -325,7 +325,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const balances = await provider.getAllAccountBalances("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049");
-console.log(`All balances: ${toJSON(balances)}`);
+console.log(`All balances: ${utils.toJSON(balances)}`);
 ```
 
 ### `getBalance`
@@ -398,7 +398,7 @@ async getBlock(blockHashOrBlockTag: BlockTag, includeTxs?: boolean): Promise<Blo
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Block: ${toJSON(await provider.getBlock("latest", true))}`);
+console.log(`Block: ${utils.toJSON(await provider.getBlock("latest", true))}`);
 ```
 
 ### `getBlockDetails`
@@ -423,7 +423,7 @@ async getBlockDetails(number:number): Promise<BlockDetails>
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Block details: ${toJSON(await provider.getBlockDetails(90_000))}`);
+console.log(`Block details: ${utils.toJSON(await provider.getBlockDetails(90_000))}`);
 ```
 
 ### `getBridgehubContractAddress`
@@ -525,7 +525,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const tokenAddress = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
-console.log(`Contract account info: ${toJSON(await provider.getContractAccountInfo(tokenAddress))}`);
+console.log(`Contract account info: ${utils.toJSON(await provider.getContractAccountInfo(tokenAddress))}`);
 ```
 
 ### `getDefaultBridgeAddresses`
@@ -549,7 +549,7 @@ getDefaultBridgeAddresses(): Promise<{
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Default bridges: ${toJSON(await provider.getDefaultBridgeAddresses())}`);
+console.log(`Default bridges: ${utils.toJSON(await provider.getDefaultBridgeAddresses())}`);
 ```
 
 ### `connectL2Bridge`
@@ -713,7 +713,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
-console.log(`L1 batch block range: ${toJSON(await provider.getL1BatchBlockRange(l1BatchNumber))}`);
+console.log(`L1 batch block range: ${utils.toJSON(await provider.getL1BatchBlockRange(l1BatchNumber))}`);
 ```
 
 ### `getL1BatchDetails`
@@ -739,7 +739,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
-console.log(`L1 batch details: ${toJSON(await provider.getL1BatchDetails(l1BatchNumber))}`);
+console.log(`L1 batch details: ${utils.toJSON(await provider.getL1BatchDetails(l1BatchNumber))}`);
 ```
 
 ### `getL1BatchNumber`
@@ -785,7 +785,7 @@ const ethProvider = ethers.getDefaultProvider("sepolia");
 const l1Tx = "0xcca5411f3e514052f4a4ae1c2020badec6e0998adb52c09959c5f5ff15fba3a8";
 const l1TxResponse = await ethProvider.getTransaction(l1Tx);
 if (l1TxResponse) {
-  console.log(`Tx: ${toJSON(await provider.getL2TransactionFromPriorityOp(l1TxResponse))}`);
+  console.log(`Tx: ${utils.toJSON(await provider.getL2TransactionFromPriorityOp(l1TxResponse))}`);
 }
 ```
 
@@ -815,7 +815,7 @@ const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 // Any L2 -> L1 transaction can be used.
 // In this case, withdrawal transaction is used.
 const tx = "0x2a1c6c74b184965c0cb015aae9ea134fd96215d2e4f4979cfec12563295f610e";
-console.log(`Log ${toJSON(await provider.getLogProof(tx, 0))}`);
+console.log(`Log ${utils.toJSON(await provider.getLogProof(tx, 0))}`);
 ```
 
 ### `getLogs`
@@ -838,7 +838,7 @@ async getLogs(filter: Filter | FilterByBlockHash): Promise<Log[]>
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Logs: ${toJSON(await provider.getLogs({ fromBlock: 0, toBlock: 5, address: utils.L2_ETH_TOKEN_ADDRESS }))}`);
+console.log(`Logs: ${utils.toJSON(await provider.getLogs({ fromBlock: 0, toBlock: 5, address: utils.L2_ETH_TOKEN_ADDRESS }))}`);
 ```
 
 ### `getMainContractAddress`
@@ -917,7 +917,7 @@ const ethProvider = ethers.getDefaultProvider("sepolia");
 const l1Tx = "0xcca5411f3e514052f4a4ae1c2020badec6e0998adb52c09959c5f5ff15fba3a8";
 const l1TxResponse = await ethProvider.getTransaction(l1Tx);
 if (l1TxResponse) {
-  console.log(`Tx: ${toJSON(await provider.getPriorityOpResponse(l1TxResponse))}`);
+  console.log(`Tx: ${utils.toJSON(await provider.getPriorityOpResponse(l1TxResponse))}`);
 }
 ```
 
@@ -966,7 +966,7 @@ const storageKey = ethers.keccak256(concatenated);
 
 const l1BatchNumber = await provider.getL1BatchNumber();
 const storageProof = await provider.getProof(utils.NONCE_HOLDER_ADDRESS, [storageKey], l1BatchNumber);
-console.log(`Storage proof: ${toJSON(storageProof)}`);
+console.log(`Storage proof: ${utils.toJSON(storageProof)}`);
 ```
 
 ### `getProtocolVersion`
@@ -1017,7 +1017,7 @@ async getRawBlockTransactions(number: number): Promise<RawBlockTransaction[]>
 import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-console.log(`Raw block transactions: ${toJSON(await provider.getRawBlockTransactions(90_000))}`);
+console.log(`Raw block transactions: ${utils.toJSON(await provider.getRawBlockTransactions(90_000))}`);
 ```
 
 ### `getTestnetPaymasterAddress`
@@ -1094,7 +1094,7 @@ import { Provider, types, utils } from "zksync-ethers";
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-console.log(`Transaction details: ${toJSON(await provider.getTransactionDetails(TX_HASH))}`);
+console.log(`Transaction details: ${utils.toJSON(await provider.getTransactionDetails(TX_HASH))}`);
 ```
 
 ### `getTransactionReceipt`
@@ -1120,7 +1120,7 @@ import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-console.log(`Transaction receipt: ${toJSON(await provider.getTransactionReceipt(TX_HASH))}`);
+console.log(`Transaction receipt: ${utils.toJSON(await provider.getTransactionReceipt(TX_HASH))}`);
 ```
 
 ### `getTransactionStatus`
@@ -1145,7 +1145,7 @@ import { Provider, types, utils } from "zksync-ethers";
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-console.log(`Transaction status: ${toJSON(await provider.getTransactionStatus(TX_HASH))}`);
+console.log(`Transaction status: ${utils.toJSON(await provider.getTransactionStatus(TX_HASH))}`);
 ```
 
 ### `getTransferTx`

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/01.provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/01.provider.md
@@ -91,7 +91,7 @@ async estimateFee(transaction: TransactionRequest): Promise<Fee>
 **Example:**
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const fee = await provider.estimateFee({
@@ -154,7 +154,7 @@ async estimateGasL1(transaction: TransactionRequest): Promise<bigint>
 **Example:**
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const gasL1 = await provider.estimateGasL1({
@@ -289,7 +289,7 @@ async estimateL1ToL2Execute(transaction: {
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const gasL1ToL2 = await provider.estimateL1ToL2Execute({
@@ -321,7 +321,7 @@ async getAllAccountBalances(address: Address): Promise<BalancesMap>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const balances = await provider.getAllAccountBalances("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049");
@@ -349,7 +349,7 @@ async getBalance(address: Address, blockTag?: BlockTag, tokenAddress?: Address)
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const account = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
@@ -371,7 +371,7 @@ async getBaseTokenContractAddress(): Promise<Address>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Base token: ${await provider.getBaseTokenContractAddress()}`);
@@ -395,7 +395,7 @@ async getBlock(blockHashOrBlockTag: BlockTag, includeTxs?: boolean): Promise<Blo
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Block: ${toJSON(await provider.getBlock("latest", true))}`);
@@ -420,7 +420,7 @@ async getBlockDetails(number:number): Promise<BlockDetails>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Block details: ${toJSON(await provider.getBlockDetails(90_000))}`);
@@ -439,7 +439,7 @@ async getBridgehubContractAddress(): Promise<Address>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Bridgehub: ${await provider.getBridgehubContractAddress()}`);
@@ -464,7 +464,7 @@ async getBytecodeByHash(bytecodeHash: BytesLike): Promise<Uint8Array>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 // Bytecode hash can be computed by following these steps:
 // const testnetPaymasterBytecode = await provider.getCode(await provider.getTestnetPaymasterAddress());
@@ -521,7 +521,7 @@ async getContractAccountInfo(address:Address): Promise<ContractAccountInfo>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const tokenAddress = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
@@ -546,7 +546,7 @@ getDefaultBridgeAddresses(): Promise<{
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Default bridges: ${toJSON(await provider.getDefaultBridgeAddresses())}`);
@@ -570,7 +570,7 @@ async connectL2Bridge(address: Address): Promise<Il2SharedBridge | Il2Bridge>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l2Bridge = await provider.connectL2Bridge("<L2_BRIDGE_ADDRESS>");
@@ -593,7 +593,7 @@ async isL2BridgeLegacy(address: Address): Promise<boolean>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const isBridgeLegacy = await provider.isL2BridgeLegacy("<L2_BRIDGE_ADDRESS>");
@@ -617,7 +617,7 @@ static getDefaultProvider(zksyncNetwork: ZkSyncNetwork = ZkSyncNetwork.Localhost
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const providerMainnet = Provider.getDefaultProvider(types.Network.Mainnet);
 const providerTestnet = Provider.getDefaultProvider(types.Network.Sepolia);
@@ -683,7 +683,7 @@ async getGasPrice(): Promise<bigint>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Gas price: ${await provider.getGasPrice()}`);
@@ -709,7 +709,7 @@ async getL1BatchBlockRange(l1BatchNumber: number): Promise<[number, number] | nu
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
@@ -735,7 +735,7 @@ async getL1BatchDetails(number: number): Promise<BatchDetails>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const l1BatchNumber = await provider.getL1BatchNumber();
@@ -755,7 +755,7 @@ async getL1BatchNumber(): Promise<number>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L1 batch number: ${await provider.getL1BatchNumber()}`);
@@ -778,7 +778,7 @@ async getL2TransactionFromPriorityOp(l1TxResponse: ethers.TransactionResponse): 
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const ethProvider = ethers.getDefaultProvider("sepolia");
@@ -809,7 +809,7 @@ async getLogProof(txHash: BytesLike, index ? : number): Promise<MessageProof | n
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 // Any L2 -> L1 transaction can be used.
@@ -854,7 +854,7 @@ async getMainContractAddress(): Promise<Address>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Main contract: ${await provider.getMainContractAddress()}`);
@@ -910,7 +910,7 @@ async getPriorityOpResponse(l1TxResponse: ethers.TransactionResponse): Promise<P
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const ethProvider = ethers.getDefaultProvider("sepolia");
@@ -988,7 +988,7 @@ async getProtocolVersion(id?: number): Promise<ProtocolVersion>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Protocol version: ${await provider.getProtocolVersion()}`);
@@ -1014,7 +1014,7 @@ async getRawBlockTransactions(number: number): Promise<RawBlockTransaction[]>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Raw block transactions: ${toJSON(await provider.getRawBlockTransactions(90_000))}`);
@@ -1032,7 +1032,7 @@ async getTestnetPaymasterAddress(): Promise<Address | null>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Testnet paymaster: ${await provider.getTestnetPaymasterAddress()}`);
@@ -1056,7 +1056,7 @@ async getTransaction(txHash: string): Promise<TransactionResponse>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
@@ -1089,7 +1089,7 @@ async getTransactionDetails(txHash: BytesLike): Promise<TransactionDetails>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
@@ -1116,7 +1116,7 @@ async getTransactionReceipt(txHash: string): Promise<TransactionReceipt>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
@@ -1140,7 +1140,7 @@ async getTransactionStatus(txHash: string): Promise<TransactionStatus>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 
@@ -1303,7 +1303,7 @@ async isBaseToken(token: Address): Promise<string>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Is base token: ${await provider.isBaseToken("0x5C221E77624690fff6dd741493D735a17716c26B")}`);
@@ -1320,7 +1320,7 @@ async isEthBasedChain(): Promise<boolean>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`Is ETH based chain: ${await provider.isEthBasedChain()}`);
@@ -1339,7 +1339,7 @@ async l1ChainId(): Promise<number>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L1 chain ID: ${await provider.l1ChainId()}`);
@@ -1366,7 +1366,7 @@ async l1TokenAddress(token: Address): Promise<string>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L1 token address: ${await provider.l1TokenAddress("0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b")}`);
@@ -1394,7 +1394,7 @@ async l2TokenAddress(token: Address): Promise<string>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`L2 token address: ${await provider.l2TokenAddress("0x5C221E77624690fff6dd741493D735a17716c26B")}`);
@@ -1411,7 +1411,7 @@ async newBlockFilter(): Promise<bigint>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`New block filter: ${await provider.newBlockFilter()}`);
@@ -1461,7 +1461,7 @@ async newPendingTransactionsFilter(): Promise<bigint>
 #### Example
 
 ```ts
-import { Provider, types } from "zksync-ethers";
+import { Provider, types, utils } from "zksync-ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
 console.log(`New pending transaction filter: ${await provider.newPendingTransactionsFilter()}`);

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/01.provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/01.provider.md
@@ -320,8 +320,6 @@ async getAllAccountBalances(address: Address): Promise<BalancesMap>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -396,8 +394,6 @@ async getBlock(blockHashOrBlockTag: BlockTag, includeTxs?: boolean): Promise<Blo
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -422,8 +418,6 @@ async getBlockDetails(number:number): Promise<BlockDetails>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -502,8 +496,6 @@ async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
 
@@ -527,8 +519,6 @@ async getContractAccountInfo(address:Address): Promise<ContractAccountInfo>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -554,8 +544,6 @@ getDefaultBridgeAddresses(): Promise<{
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -649,8 +637,6 @@ async getFeeParams(): Promise<FeeParams>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
 
@@ -722,8 +708,6 @@ async getL1BatchBlockRange(l1BatchNumber: number): Promise<[number, number] | nu
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -749,8 +733,6 @@ async getL1BatchDetails(number: number): Promise<BatchDetails>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -795,8 +777,6 @@ async getL2TransactionFromPriorityOp(l1TxResponse: ethers.TransactionResponse): 
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -828,8 +808,6 @@ async getLogProof(txHash: BytesLike, index ? : number): Promise<MessageProof | n
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -855,8 +833,6 @@ async getLogs(filter: Filter | FilterByBlockHash): Promise<Log[]>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
@@ -906,8 +882,6 @@ async getPriorityOpConfirmation(txHash: string, index: number = 0): Promise<{
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
 
@@ -934,8 +908,6 @@ async getPriorityOpResponse(l1TxResponse: ethers.TransactionResponse): Promise<P
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -969,8 +941,6 @@ async getProof(address: Address, keys: string[], l1BatchNumber: number): Promise
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types, utils } from "zksync-ethers";
@@ -1042,8 +1012,6 @@ async getRawBlockTransactions(number: number): Promise<RawBlockTransaction[]>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -1120,8 +1088,6 @@ async getTransactionDetails(txHash: BytesLike): Promise<TransactionDetails>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -1149,8 +1115,6 @@ async getTransactionReceipt(txHash: string): Promise<TransactionReceipt>
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, types } from "zksync-ethers";
 
@@ -1174,8 +1138,6 @@ async getTransactionStatus(txHash: string): Promise<TransactionStatus>
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, types } from "zksync-ethers";
@@ -1531,8 +1493,6 @@ async sendRawTransactionWithDetailedOutput(signedTx: string): Promise<Transactio
 ```
 
 #### Example
-
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
 
 ```ts
 import { Provider, Wallet, types, utils } from "zksync-ethers";

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/02.browser-provider.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/00.providers/02.browser-provider.md
@@ -791,18 +791,3 @@ const signer = await provider.getSigner();
 // Verify that signer matches the expected wallet address.
 console.log(`Signer address: ${await signer.getAddress()}`);
 ```
-
-## Appendix
-
-### toJSON
-
-```ts
-function toJSON(object: any): string {
-  return JSON.stringify(object, (key, value) => {
-    if (typeof value === "bigint") {
-      return value.toString(); // Convert BigInt to string
-    }
-    return value;
-  });
-}
-```

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/01.accounts/01.wallet.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/01.accounts/01.wallet.md
@@ -1830,8 +1830,6 @@ async getPriorityOpConfirmation(txHash: string, index: number = 0): Promise<{
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Wallet, Provider, types, utils } from "zksync-ethers";
 import { ethers } from "ethers";

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/01.accounts/03.l1signer.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/01.accounts/03.l1signer.md
@@ -10,7 +10,7 @@ This class extends `ethers.JsonRpcSigner` and so supports all the methods availa
 The easiest way to construct it is from an `BrowserProvider` object.
 
 ```ts
-import { Provider, L1Signer, types } from "zksync-ethers";
+import { Provider, L1Signer, types, utils } from "zksync-ethers";
 import { ethers } from "ethers";
 
 const provider = new ethers.BrowserProvider(window.ethereum);

--- a/content/sdk/10.js/00.ethers/05.api/20.v6/01.accounts/03.l1signer.md
+++ b/content/sdk/10.js/00.ethers/05.api/20.v6/01.accounts/03.l1signer.md
@@ -1084,8 +1084,6 @@ async getPriorityOpConfirmation(txHash: string, index: number = 0): Promise<{
 
 #### Example
 
-Helper function: [toJSON](/sdk/js/ethers/api/v6/providers/browser-provider#tojson).
-
 ```ts
 import { Provider, L1Signer, types } from "zksync-ethers";
 import { ethers } from "ethers";


### PR DESCRIPTION
## What:
I removed the appendix for the `toJSON` function in our codebase.

## Why:
I made this change to clean up the code by removing unnecessary parts. This improves the readability and maintainability of the `toJSON` function, ensuring it operates more efficiently without any redundant elements. This also resolves occasional bugs linked to the appendix, enhancing the function's stability.