### PR TITLE
feat: v6 types page has v5 links

### DIFF
--- a/content/10.js/00.ethers/05.api/20.v6/05.types.md
+++ b/content/10.js/00.ethers/05.api/20.v6/05.types.md
@@ -116,7 +116,7 @@ Interface representation of batch details.
 ## `Block`
 
 Interface representation of a block that extends the Ethers
-[`providers.Block`](https://docs.ethers.org/v5/api/providers/types/#providers-Block)
+[`providers.Block`](https://docs.ethers.org/v6/api/providers/#Block)
 definition with additional fields.
 
 ::field-group
@@ -471,7 +471,7 @@ Interface representation of a layer 2 to layer 1 transaction log.
 ## `Log`
 
 Interface representation of log that extends Ethers
-[`providers.Log`](https://docs.ethers.org/v5/api/providers/types/#providers-Log)
+[`providers.Log`](https://docs.ethers.org/v6/api/providers/#Log)
 and supplies the layer 1 batch number.
 
 ::field-group
@@ -856,7 +856,7 @@ Interface representation of transaction details.
 ## `TransactionReceipt`
 
 Interface representation of transaction receipt that extends from Ethers
-[`providers.TransactionReceipt`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionReceipt)
+[`providers.TransactionReceipt`](https://docs.ethers.org/v6/api/providers/#TransactionReceipt)
 with additional fields.
 
 ::field-group
@@ -879,7 +879,7 @@ with additional fields.
 ## `TransactionRequest`
 
 Interface representation of transaction request that extends from Ethers
-[`providers.TransactionRequest`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionRequest)
+[`providers.TransactionRequest`](https://docs.ethers.org/v6/api/providers/#TransactionRequest)
 which adds an optional field for EIP-712 transactions.
 
 ::field-group
@@ -893,7 +893,7 @@ which adds an optional field for EIP-712 transactions.
 ## `TransactionResponse`
 
 Interface representation of transaction response that extends from Ethers
-[`providers.TransactionResponse`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionResponse)
+[`providers.TransactionResponse`](https://docs.ethers.org/v6/api/providers/#TransactionResponse)
 with additional fields.
 
 ::field-group

--- a/content/10.js/00.ethers/05.api/20.v6/05.types.md
+++ b/content/10.js/00.ethers/05.api/20.v6/05.types.md
@@ -116,7 +116,7 @@ Interface representation of batch details.
 ## `Block`
 
 Interface representation of a block that extends the Ethers
-[`providers.Block`](https://docs.ethers.org/v5/api/providers/types/#providers-Block)
+[`providers.Block`](https://docs.ethers.org/v6/api/providers/types/#providers-Block)
 definition with additional fields.
 
 ::field-group
@@ -471,7 +471,7 @@ Interface representation of a layer 2 to layer 1 transaction log.
 ## `Log`
 
 Interface representation of log that extends Ethers
-[`providers.Log`](https://docs.ethers.org/v5/api/providers/types/#providers-Log)
+[`providers.Log`](https://docs.ethers.org/v6/api/providers/types/#providers-Log)
 and supplies the layer 1 batch number.
 
 ::field-group
@@ -856,7 +856,7 @@ Interface representation of transaction details.
 ## `TransactionReceipt`
 
 Interface representation of transaction receipt that extends from Ethers
-[`providers.TransactionReceipt`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionReceipt)
+[`providers.TransactionReceipt`](https://docs.ethers.org/v6/api/providers/types/#providers-TransactionReceipt)
 with additional fields.
 
 ::field-group
@@ -879,7 +879,7 @@ with additional fields.
 ## `TransactionRequest`
 
 Interface representation of transaction request that extends from Ethers
-[`providers.TransactionRequest`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionRequest)
+[`providers.TransactionRequest`](https://docs.ethers.org/v6/api/providers/types/#providers-TransactionRequest)
 which adds an optional field for EIP-712 transactions.
 
 ::field-group
@@ -893,7 +893,7 @@ which adds an optional field for EIP-712 transactions.
 ## `TransactionResponse`
 
 Interface representation of transaction response that extends from Ethers
-[`providers.TransactionResponse`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionResponse)
+[`providers.TransactionResponse`](https://docs.ethers.org/v6/api/providers/types/#providers-TransactionResponse)
 with additional fields.
 
 ::field-group

--- a/content/10.js/00.ethers/05.api/20.v6/05.types.md
+++ b/content/10.js/00.ethers/05.api/20.v6/05.types.md
@@ -116,7 +116,7 @@ Interface representation of batch details.
 ## `Block`
 
 Interface representation of a block that extends the Ethers
-[`providers.Block`](https://docs.ethers.org/v6/api/providers/types/#providers-Block)
+[`providers.Block`](https://docs.ethers.org/v5/api/providers/types/#providers-Block)
 definition with additional fields.
 
 ::field-group
@@ -471,7 +471,7 @@ Interface representation of a layer 2 to layer 1 transaction log.
 ## `Log`
 
 Interface representation of log that extends Ethers
-[`providers.Log`](https://docs.ethers.org/v6/api/providers/types/#providers-Log)
+[`providers.Log`](https://docs.ethers.org/v5/api/providers/types/#providers-Log)
 and supplies the layer 1 batch number.
 
 ::field-group
@@ -856,7 +856,7 @@ Interface representation of transaction details.
 ## `TransactionReceipt`
 
 Interface representation of transaction receipt that extends from Ethers
-[`providers.TransactionReceipt`](https://docs.ethers.org/v6/api/providers/types/#providers-TransactionReceipt)
+[`providers.TransactionReceipt`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionReceipt)
 with additional fields.
 
 ::field-group
@@ -879,7 +879,7 @@ with additional fields.
 ## `TransactionRequest`
 
 Interface representation of transaction request that extends from Ethers
-[`providers.TransactionRequest`](https://docs.ethers.org/v6/api/providers/types/#providers-TransactionRequest)
+[`providers.TransactionRequest`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionRequest)
 which adds an optional field for EIP-712 transactions.
 
 ::field-group
@@ -893,7 +893,7 @@ which adds an optional field for EIP-712 transactions.
 ## `TransactionResponse`
 
 Interface representation of transaction response that extends from Ethers
-[`providers.TransactionResponse`](https://docs.ethers.org/v6/api/providers/types/#providers-TransactionResponse)
+[`providers.TransactionResponse`](https://docs.ethers.org/v5/api/providers/types/#providers-TransactionResponse)
 with additional fields.
 
 ::field-group


### PR DESCRIPTION
### What

- Updated the V6 types page to remove or replace V5 links incorrectly referenced.

### Why

- The V6 types page had outdated links pointing to V5, which could cause confusion or incorrect navigation for users. This update ensures all references are correctly aligned with V6.
