### PR TITLE
fix: incorrect text on Swift page

### DIFF
--- a/content/50.swift/00.introduction/02.installation.md
+++ b/content/50.swift/00.introduction/02.installation.md
@@ -12,7 +12,7 @@ Setting up `zksync2-swift` in your project is straightforward. Follow these step
 - macOS: >= 11.0
 
 ::callout{icon="i-heroicons-light-bulb"}
-Check out the [Java installation guide](https://www.swift.org/download) for more information.
+Check out the [Swift installation guide](https://www.swift.org/download) for more information.
 ::
 
 ### CocoaPods integration


### PR DESCRIPTION
### What

- incorrect text on Swift page

### Why

- Remove contradictory text to avoid conflcts