### PR TITLE
fix: correct wrong URL for the sepolia RPC URL

### DIFF
--- a/content/80.troubleshooting.md
+++ b/content/80.troubleshooting.md
@@ -13,7 +13,7 @@ functionalities, here are detailed solutions and best practices to ensure a smoo
 If you encounter issues using the JavaScript SDK during the installation, refer to the troubleshooting steps:
 
 1. **Network selection**: Ensure you are using the Layer 2 (L2) network instead of Layer 1 (L1) Sepolia. The
-correct endpoint for the L2 network is: [ZKsync Sepolia Explorer](https://sepolia.era.zksync.dev).
+correct endpoint for the L2 network is: [ZKsync Sepolia Explorer](%%zk_testnet_rpc_url%%).
 
 2. **Transaction hash and block tag**: Use the correct transaction hash and block tag when fetching transaction details.
 

--- a/content/80.troubleshooting.md
+++ b/content/80.troubleshooting.md
@@ -13,7 +13,7 @@ functionalities, here are detailed solutions and best practices to ensure a smoo
 If you encounter issues using the JavaScript SDK during the installation, refer to the troubleshooting steps:
 
 1. **Network selection**: Ensure you are using the Layer 2 (L2) network instead of Layer 1 (L1) Sepolia. The
-correct endpoint for the L2 network is: [ZKsync Sepolia Explorer](%%zk_testnet_block_explorer_url%%/).
+correct endpoint for the L2 network is: [ZKsync Sepolia Explorer](https://sepolia.era.zksync.dev).
 
 2. **Transaction hash and block tag**: Use the correct transaction hash and block tag when fetching transaction details.
 


### PR DESCRIPTION
<!--

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/zksync-sdk/sdk-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/zksync-sdk/sdk-docs/blob/main/CODE_OF_CONDUCT.md)

-->

# Description


This PR changes the endpoint mentioned for the L2 network in **JavaScript SDK** section of the **Troubleshooting** page from  https://sepolia.explorer.zksync.io/ to https://sepolia.era.zksync.dev/.

## Linked Issues

<!-- If you have any issues this PR is related to, link them here. -->
Fixes issue https://github.com/zksync-sdk/sdk-docs/issues/53 

