### PR TITLE
fix(content/python/api/contracts/index): Add max_priority_fee_per_gas=0 if testnet

### DIFF
--- a/content/30.python/40.api/30.contracts/00.index.md
+++ b/content/30.python/40.api/30.contracts/00.index.md
@@ -112,6 +112,7 @@ def deploy_contract(
         gas_limit=0,  # UNKNOWN AT THIS STATE
         gas_price=gas_price,
         bytecode=storage_contract.bytecode,
+        max_priority_fee_per_gas=0, # if testnet
     )
 
     # ZkSync transaction gas estimation
@@ -247,7 +248,8 @@ _web3.zksync.gas_price
                                          gas_limit=0,
                                          gas_price=gas_price,
                                          bytecode=storage_contract.bytecode,
-                                         salt=random_salt)
+                                         salt=random_salt,
+                                         max_priority_fee_per_gas=0)
 
     # ZkSync transaction gas estimation
     estimate_gas = zk_web3.zksync.eth_estimate_gas(create2_contract.tx)


### PR DESCRIPTION
<!--

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/zksync-sdk/sdk-docs/blob/main/CONTRIBUTING.md).
- Understand our [Code of Conduct](https://github.com/zksync-sdk/sdk-docs/blob/main/CODE_OF_CONDUCT.md)

-->

# Description

[According to the dev of zksync2-python](https://github.com/zksync-sdk/zksync2-python/issues/76#issuecomment-2380714490), default priority fee on Sepolia testnet is different from Mainnet. This leads the contract deployment example from the docs to fail when used on Sepolia, but presumably work properly on Mainnet. Creator of the issue and I have personally stumbled upon this bug/ambiguity.

```
File "/Users/jordan/Desktop/untron-2/cli/untroncli.py", line 126, in deploy_implementation
    tx_hash = zk_web3.zksync.send_raw_transaction(msg)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/web3/eth/eth.py", line 396, in send_raw_transaction
    return self._send_raw_transaction(transaction)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/web3/module.py", line 75, in caller
    result = w3.manager.request_blocking(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/web3/manager.py", line 330, in request_blocking
    return self.formatted_response(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/web3/manager.py", line 293, in formatted_response
    raise ValueError(error)
ValueError: {'code': 3, 'message': 'max priority fee per gas higher than max fee per gas', 'data': '0x'}
```

I added `max_priority_fee_per_gas=0 # if testnet` field on all TxCreateContract and TxCreate2Contract examples. I believe this must be mentioned in the docs, as most deployments in dev environment happen on testnet. However, let me know if I should mention this differently/in some different place of the page.

## Linked Issues

Mentioned above

## Additional context

-